### PR TITLE
fix: typo in Dockerfiles

### DIFF
--- a/attack-predictor/1.0.0/Dockerfile
+++ b/attack-predictor/1.0.0/Dockerfile
@@ -5,7 +5,7 @@ FROM frikky/shuffle:app_sdk as base
 FROM base as builder
 
 # Install all alpine build tools needed for our pip installs
-RUN apk py3-numpy py3-pandas@testing
+RUN apk add py3-numpy py3-pandas@testing
 RUN apk --no-cache add --update alpine-sdk libffi libffi-dev musl-dev openssl-dev
 
 # Install all of our pip packages in a single directory that we can copy to our base image later

--- a/snort3/1.0.0/Dockerfile
+++ b/snort3/1.0.0/Dockerfile
@@ -24,7 +24,7 @@ RUN echo 'https://dl-cdn.alpinelinux.org/alpine/edge/community' >> /etc/apk/repo
     pcre-dev \
     libtirpc-dev \
     flatbuffers-dev \ 
-    hyperscan-dev \
+    vectorscan-dev \
     flex-dev
 
 ENV SRC_HOME=/snort_src


### PR DESCRIPTION
attack-predictor: Miss `add` in `apk` command
snort3: renamed hyperscan package