### PR TITLE
Enable using AWS services with ec2role

### DIFF
--- a/aws-cloudwatch/1.0.0/api.yaml
+++ b/aws-cloudwatch/1.0.0/api.yaml
@@ -15,13 +15,13 @@ authentication:
     - name: access_key 
       description: The access key to use
       example: "*****"
-      required: true
+      required: false
       schema:
         type: string
     - name: secret_key
       description: The secret key to use 
       example: "*****"
-      required: true
+      required: false
       schema:
         type: string
     - name: region 

--- a/aws-cloudwatch/1.0.0/src/app.py
+++ b/aws-cloudwatch/1.0.0/src/app.py
@@ -49,12 +49,18 @@ class CloudWatch(AppBase):
             },
         )
 
-        self.cloudwatch = boto3.client(
-            'logs', 
-            config = my_config, 
-            aws_access_key_id = access_key,
-            aws_secret_access_key = secret_key,
-        )
+        if access_key!="":
+            self.cloudwatch = boto3.resource(
+                'logs', 
+                config=my_config, 
+                aws_access_key_id=access_key,
+                aws_secret_access_key=secret_key,
+            )
+        else:
+            self.cloudwatch = boto3.resource(
+                'logs', 
+                config=my_config,
+            )
         print(self.cloudwatch)
         return self.cloudwatch
 

--- a/aws-dynamodb/1.0.0/api.yaml
+++ b/aws-dynamodb/1.0.0/api.yaml
@@ -17,13 +17,13 @@ authentication:
     - name: access_key 
       description: The access key to use
       example: "*****"
-      required: true
+      required: false
       schema:
         type: string
     - name: secret_key
       description: The secret key to use 
       example: "*****"
-      required: true
+      required: false
       schema:
         type: string
     - name: region 

--- a/aws-dynamodb/1.0.0/src/app.py
+++ b/aws-dynamodb/1.0.0/src/app.py
@@ -32,12 +32,18 @@ class AWSDynamoDB(AppBase):
             },
         )
 
-        self.dynamodb = boto3.resource(
-            'dynamodb', 
-            config=my_config, 
-            aws_access_key_id=access_key,
-            aws_secret_access_key=secret_key,
-        )
+        if access_key!="":
+            self.dynamodb = boto3.resource(
+                'dynamodb', 
+                config=my_config, 
+                aws_access_key_id=access_key,
+                aws_secret_access_key=secret_key,
+            )
+        else:
+            self.dynamodb = boto3.resource(
+                'dynamodb', 
+                config=my_config,
+            )
 
         return self.dynamodb
 

--- a/aws-ec2/1.0.0/api.yaml
+++ b/aws-ec2/1.0.0/api.yaml
@@ -17,13 +17,13 @@ authentication:
     - name: access_key 
       description: The access key to use
       example: "*****"
-      required: true
+      required: false
       schema:
         type: string
     - name: secret_key
       description: The secret key to use 
       example: "*****"
-      required: true
+      required: false
       schema:
         type: string
     - name: region 

--- a/aws-ec2/1.0.0/src/app.py
+++ b/aws-ec2/1.0.0/src/app.py
@@ -41,12 +41,18 @@ class AWSEC2(AppBase):
             },
         )
 
-        self.ec2 = boto3.resource(
-            'ec2', 
-            config = my_config, 
-            aws_access_key_id = access_key,
-            aws_secret_access_key = secret_key,
-        )
+        if access_key!="":
+            self.ec2 = boto3.resource(
+                'ec2', 
+                config=my_config, 
+                aws_access_key_id=access_key,
+                aws_secret_access_key=secret_key,
+            )
+        else:
+            self.ec2 = boto3.resource(
+                'ec2', 
+                config=my_config,
+            )
 
         return self.ec2
 

--- a/aws-guardduty/1.0.0/api.yaml
+++ b/aws-guardduty/1.0.0/api.yaml
@@ -17,13 +17,13 @@ authentication:
     - name: access_key 
       description: The access key to use
       example: "*****"
-      required: true
+      required: false
       schema:
         type: string
     - name: secret_key
       description: The secret key to use 
       example: "*****"
-      required: true
+      required: false
       schema:
         type: string
     - name: region 

--- a/aws-guardduty/1.0.0/src/app.py
+++ b/aws-guardduty/1.0.0/src/app.py
@@ -32,14 +32,19 @@ class AWSGuardduty(AppBase):
             },
         )
 
-        return boto3.client(
-            'guardduty', 
-            config=my_config, 
-            aws_access_key_id=access_key,
-            aws_secret_access_key=secret_key,
-        )
-
-
+        if access_key!="":
+            return boto3.client(
+                'guardduty', 
+                config=my_config, 
+                aws_access_key_id=access_key,
+                aws_secret_access_key=secret_key,
+            )
+        else:
+            return boto3.client(
+                'guardduty', 
+                config=my_config, 
+            )
+        
     def create_detector(self, access_key, secret_key, region, enable):
         client = self.auth_guardduty(access_key, secret_key, region)
         try:

--- a/aws-iam/1.0.0/api.yaml
+++ b/aws-iam/1.0.0/api.yaml
@@ -16,13 +16,13 @@ authentication:
     - name: access_key 
       description: The access key to use
       example: "*****"
-      required: true
+      required: false
       schema:
         type: string
     - name: secret_key
       description: The secret key to use 
       example: "*****"
-      required: true
+      required: false
       schema:
         type: string
     - name: region 

--- a/aws-iam/1.0.0/src/app.py
+++ b/aws-iam/1.0.0/src/app.py
@@ -41,12 +41,18 @@ class AWSIAM(AppBase):
             },
         )
 
-        self.iam = boto3.resource(
-            'iam', 
-            config=my_config, 
-            aws_access_key_id=access_key,
-            aws_secret_access_key=secret_key,
-        )
+        if access_key!="":
+            self.iam = boto3.resource(
+                'iam', 
+                config=my_config, 
+                aws_access_key_id=access_key,
+                aws_secret_access_key=secret_key,
+            )
+        else:
+            self.iam = boto3.resource(
+                'iam', 
+                config=my_config,
+            )
 
         return self.iam
 

--- a/aws-lambda/1.0.0/api.yaml
+++ b/aws-lambda/1.0.0/api.yaml
@@ -16,13 +16,13 @@ authentication:
     - name: access_key 
       description: The access key to use
       example: "*****"
-      required: true
+      required: false
       schema:
         type: string
     - name: secret_key
       description: The secret key to use 
       example: "*****"
-      required: true
+      required: false
       schema:
         type: string
     - name: region 

--- a/aws-lambda/1.0.0/src/app.py
+++ b/aws-lambda/1.0.0/src/app.py
@@ -31,13 +31,19 @@ class AWSLambda(AppBase):
                 'mode': 'standard'
             },
         )
-
-        return boto3.client(
-            'lambda', 
-            config=my_config, 
-            aws_access_key_id=access_key,
-            aws_secret_access_key=secret_key,
-        )
+        
+        if access_key!="":
+            return boto3.client(
+                'lambda', 
+                config=my_config, 
+                aws_access_key_id=access_key,
+                aws_secret_access_key=secret_key,
+            )
+        else:
+            return boto3.client(
+                'lambda', 
+                config=my_config, 
+            )
 
 
     def list_functions(self, access_key, secret_key, region):

--- a/aws-s3/1.0.0/api.yaml
+++ b/aws-s3/1.0.0/api.yaml
@@ -17,13 +17,13 @@ authentication:
     - name: access_key 
       description: The access key to use
       example: "*****"
-      required: true
+      required: false
       schema:
         type: string
     - name: secret_key
       description: The secret key to use 
       example: "*****"
-      required: true
+      required: false
       schema:
         type: string
     - name: region 

--- a/aws-s3/1.0.0/src/app.py
+++ b/aws-s3/1.0.0/src/app.py
@@ -32,12 +32,18 @@ class AWSS3(AppBase):
             },
         )
 
-        self.s3 = boto3.resource(
-            's3', 
-            config=my_config, 
-            aws_access_key_id=access_key,
-            aws_secret_access_key=secret_key,
-        )
+        if access_key!="":
+            self.s3 = boto3.resource(
+                's3', 
+                config=my_config, 
+                aws_access_key_id=access_key,
+                aws_secret_access_key=secret_key,
+            )
+        else:
+            self.s3 = boto3.resource(
+                's3', 
+                config=my_config,
+            )
 
         return self.s3
 


### PR DESCRIPTION
Normally in Shuffle AWS apps needs credentials to be used.
If you give a necessary permissions(list bucket, create waf block ip etc.) with an  ec2role to the server that Shuffle installed then you don't need to enter credentials in the app. 
I put a small check for this in the code and change the requirements in the api.yaml
