### PR TITLE
Add custom endpoint support to aws s3 tile

### DIFF
--- a/aws-s3/1.0.0/api.yaml
+++ b/aws-s3/1.0.0/api.yaml
@@ -32,6 +32,12 @@ authentication:
       required: true
       schema:
         type: string
+    - name: endpoint_url
+      description: The endpoint to use. 'default' or blank for default endpoint
+      example: "http://localhost:9000"
+      required: false
+      schema:
+        type: string
 actions:
   - name: create_bucket 
     description: Creates a bucket with the specified name


### PR DESCRIPTION
I saw a need to add support for custom endpoints in the AWS S3 tile. This is used whenever someone is using some AWS S3 alternative such as S3 Garage or MinIO. 
As such, I added a non-required field under "authentication" to request an endpoint. If an endpoint is not give, or if "default" is used, it will use the default AWS endpoint. If an endpoint is specified, then that endpoint will be used in the boto3 library. 