### PR TITLE
Filter List - Equals Any Of - FIX

### DIFF
--- a/shuffle-tools/1.2.0/src/app.py
+++ b/shuffle-tools/1.2.0/src/app.py
@@ -811,6 +811,7 @@ class Tools(AppBase):
                         failed_list.append(item)
 
                 elif check == "equals any of":
+                    value = self.parse_list_internal(value)
                     checklist = value.split(",")
                     found = False
                     for subcheck in checklist:


### PR DESCRIPTION
Fix array parsing in **Filter List** of Shuffle-Tools node when filtering by "equals any of". Before this fix "equals any of" where never matching data in a array because it wasn't parsing it the same way "contains any of" parses.